### PR TITLE
Don't force use of root URL when making requests

### DIFF
--- a/lib/billing_facade_client.rb
+++ b/lib/billing_facade_client.rb
@@ -21,7 +21,7 @@ module BillingFacadeClient
   @site = ENV['BILLING_FACADE_URL']
 
   def self.send_event(work_order, name)
-    r = connection.post("/events", {eventName: name, workOrderId: work_order.id}.to_json)
+    r = connection.post("events", {eventName: name, workOrderId: work_order.id}.to_json)
     return true if r.status==200
     return false
   end
@@ -42,7 +42,7 @@ module BillingFacadeClient
   end
 
   def self.get_cost_information_for_products(cost_code, product_names)
-    r = connection.post("/accounts/#{cost_code}/unit_price", product_names.to_json)
+    r = connection.post("accounts/#{cost_code}/unit_price", product_names.to_json)
     response = JSON.parse(r.body, symbolize_names: true)
     return response
   end
@@ -57,27 +57,27 @@ module BillingFacadeClient
   end
 
   def self.validate_process_module_name(module_name)
-    r = connection.get("/modules/#{module_name}/verifyname")
+    r = connection.get("modules/#{module_name}/verifyname")
     response = JSON.parse(r.body, symbolize_names: true)
     return response[:verified]
   end
 
   def self.get_sub_cost_codes(cost_code)
-    r = connection.get("/accounts/#{cost_code}/subaccountcodes")
+    r = connection.get("accounts/#{cost_code}/subaccountcodes")
     response = JSON.parse(r.body, symbolize_names: true)
     return response[:subCostCodes]
   end
 
   def self.validate_product_name?(product_name)
-    validate_single_value("/products/#{product_name}/verify")
+    validate_single_value("products/#{product_name}/verify")
   end
 
   def self.validate_project_cost_code?(cost_code)
-    validate_single_value("/accounts/#{cost_code}/verify")
+    validate_single_value("accounts/#{cost_code}/verify")
   end
 
   def self.validate_subproject_cost_code?(cost_code)
-    validate_single_value("/subaccountcodes/#{cost_code}/verify")
+    validate_single_value("subaccountcodes/#{cost_code}/verify")
   end
 
   def self.validate_cost_code?(cost_code)
@@ -85,11 +85,11 @@ module BillingFacadeClient
   end
 
   def self.filter_invalid_cost_codes(cost_codes)
-    validate_multiple_values("/accounts/verify", {accounts: cost_codes})
+    validate_multiple_values("accounts/verify", {accounts: cost_codes})
   end
 
   def self.filter_invalid_product_names(product_names_list)
-    validate_multiple_values("/catalogue/verify", {products: product_names_list})
+    validate_multiple_values("catalogue/verify", {products: product_names_list})
   end
 
   def self.connection

--- a/lib/billing_facade_client/cost_for_module.rb
+++ b/lib/billing_facade_client/cost_for_module.rb
@@ -6,7 +6,7 @@ module BillingFacadeClient
     # - The Cost code and Module name in the response match the arguments provided
     # - The Price obtained is a valid numeric value
     def validate_response_cost_for_module_name(response,  module_name, cost_code)
-      !!((response) && (!response[:errors]) && 
+      !!((response) && (!response[:errors]) &&
         (response[:cost_code] == cost_code) && (response[:module] == module_name) &&
         (price_is_valid?(response[:price])))
     end
@@ -14,7 +14,7 @@ module BillingFacadeClient
     # Given a product name and a module name for it, and a cost code, it performs a query to the billing
     # facade service and returns the price value
     def get_cost_information_for_module(module_name, cost_code)
-      r = connection.post("/price_for_module", msg_request_cost_information_for_module(module_name, cost_code))
+      r = connection.post("price_for_module", msg_request_cost_information_for_module(module_name, cost_code))
       response = JSON.parse(r.body, symbolize_names: true)
       if validate_response_cost_for_module_name(response, module_name, cost_code)
         return BigDecimal.new(response[:price])
@@ -26,7 +26,7 @@ module BillingFacadeClient
     # Generates a valid request JSON to ask for a price to the billing facade for a module and costcode
     def msg_request_cost_information_for_module(module_name, cost_code)
       obj = {}
-      obj[:module] = module_name      
+      obj[:module] = module_name
       obj[:cost_code] = cost_code
       obj.to_json
     end

--- a/lib/billing_facade_client/version.rb
+++ b/lib/billing_facade_client/version.rb
@@ -1,3 +1,3 @@
 module BillingFacadeClient
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
The trailing slashes would only allow the app to work if the specified billing service was running in the root, e.g "https://site.com:1234/" . This change allows it to also work when running from a directory, e.g "https://site.com:1234/billing_mock".